### PR TITLE
Fix release workflow tag push and version detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,12 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
Grant contents: write so the runner's GITHUB_TOKEN can push the new tag, and fetch full history/tags on checkout so the version bump is computed from the actual latest tag