### PR TITLE
Fix releases 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,14 +78,15 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GHE_TOKEN }}
-        with:
-          release_name: "${{ steps.bump_semver.outputs.tag }}"
-          tag_name: ${{ steps.bump_semver.outputs.tag }}
-          draft: true
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag=${{ steps.bump_semver.outputs.tag }}
+          html_url=$(gh release create "${tag}" \
+            --title "${tag}" \
+            --notes-file changelog.md \
+            --draft)
+          echo "html_url=${html_url}" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          tag=${{ steps.bump_semver.outputs.tag }}
+          tag="${{ steps.bump_semver.outputs.tag }}"
+          echo "RELEASE_NAME=${tag}" >> "$GITHUB_ENV"
           html_url=$(gh release create "${tag}" \
             --title "${tag}" \
             --notes-file changelog.md \


### PR DESCRIPTION
actions/create-release@v1 is unmaintained and required a GHE_TOKEN secret that isn't configured on this repo, causing an empty-token failure. Use gh release create with the built-in GITHUB_TOKEN, which already has contents: write from the earlier permissions fix.